### PR TITLE
Region to get_cluster_stats() calls added

### DIFF
--- a/check_elasticache.py
+++ b/check_elasticache.py
@@ -341,7 +341,7 @@ def main():
             parser.error('Unit is not valid.')
 
         info = get_cluster_info(options.region, options.ident)
-        used_memory = get_cluster_stats(options.node, 60, tm -
+        used_memory = get_cluster_stats(options.region, options.node, 60, tm -
                                         datetime.timedelta(seconds=60), tm,
                                         metrics[options.metric], options.ident)
         if not info or not used_memory:
@@ -396,7 +396,7 @@ def main():
                          'greater than warning.')
 
         info = get_cluster_info(options.region, options.ident)
-        swap = get_cluster_stats(options.node, 60, tm -
+        swap = get_cluster_stats(options.region, options.node, 60, tm -
                                  datetime.timedelta(seconds=60), tm,
                                  metrics[options.metric], options.ident)
         if not info or not isinstance(swap, float):


### PR DESCRIPTION
solves TypeError: get_cluster_stats() takes exactly 7 arguments (6
given) for metrics memory and swap
