### PR TITLE
CPU Utilization not Load Average

### DIFF
--- a/check_elasticache.py
+++ b/check_elasticache.py
@@ -255,7 +255,7 @@ def main():
                                           info['EngineVersion'],
                                           info['CacheClusterStatus'])
 
-    # ElastiCache Load Average
+    # ElastiCache CPU Utilization
     elif options.metric == 'cpu':
         info = get_cluster_info(options.region, options.ident)
         if not info:
@@ -322,7 +322,7 @@ def main():
         if status != UNKNOWN:
             if status is None:
                 status = OK
-            note = 'Load average: %s%%' % '%, '.join(cpus)
+            note = 'CPU Utilization: %s%%' % '%, '.join(cpus)
             perf_data = ' '.join(perf_data)
 
     # ElastiCache Free Memory


### PR DESCRIPTION
According this document https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.WhichShouldIMonitor.html#metrics-cpu-utilization
It should be CPU Utilization not Load Average